### PR TITLE
fix: compatibility with LuaJIT (and Lua 5.1)

### DIFF
--- a/lua/snippet_converter/core/vscode/vsnip/body_parser.lua
+++ b/lua/snippet_converter/core/vscode/vsnip/body_parser.lua
@@ -30,7 +30,9 @@ local NodeType = require("snippet_converter.core.node_type")
 local VSnipParser = VSCodeParser:new {
   Variable = setmetatable(VSCodeParser.Variable, { __index = { VIM = "VIM" } }),
 }
-VSnipParser.variable_tokens = { table.unpack(VSCodeParser.variable_tokens) }
+
+local unpack = table.unpack or unpack
+VSnipParser.variable_tokens = { unpack(VSCodeParser.variable_tokens) }
 table.insert(VSnipParser.variable_tokens, "VIM")
 
 local var_pattern = "[_a-zA-Z][_a-zA-Z0-9]*"


### PR DESCRIPTION
Thanks for this plugin, it saved me quite a bit of time converting my snippets. I'm using nvim+LuaJIT though, so I had to slightly patch the plugin to make it work for me.