### PR TITLE
feat: add option to disable generating package.json file

### DIFF
--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -99,7 +99,7 @@ If not specified, a default value (the index of the template in the `templates` 
 
 ---
 
-`sources: table <string, string>`
+`sources: table <string, string[]>`
 
 A table with a list of paths per source format.
 For a list of available source formats, see [Supported snippet formats](#supported-snippet-formats).
@@ -110,11 +110,11 @@ path of the same template will be ignored! This is to avoid reconverting snippet
 
 ---
 
-`output: table <string, string>`
+`output: table<string, string[] | table>`
 
 A table with a list of paths per output format where the converted snippets will be stored.
-Each path must be an absolute path to a directory.
-If a directory does not exist, it will be created.
+Each path must be an absolute path to a directory. If a directory does not exist, it will be created.
+Can optionally contain an `opts` table with additional options (see [Output format options](#output-format-options)).
 See [Recommended output paths](#transforming-snippets) for advice on how to choose a suitable output path.
 
 ---
@@ -176,6 +176,23 @@ For details, always refer to the documentation of your snippet engine.
   ```lua
   vim.fn.stdpath("config") .. "/snippets"
   ```
+
+## Output format options
+You can set additional options by passing an `opts` table to the output format.
+Currently there is only one option which is useful for `vscode` or `vscode_luasnip` output formats:
+```lua
+output = {
+  vscode_luasnip = {
+    vim.fn.stdpath("config") .. "/vscode_snippets",
+    opts = {
+      -- Whether a package.json file should be generated in the output root directory.
+      -- This is useful if you only want to modify existing VSCode snippets without overwriting the package.json file.
+      -- Default: `true`
+      generate_package_json = false, 
+    },
+  },
+}
+```
 
 # Transforming snippets
 Before snippets are converted, it is possible to apply a transformation on them. Transformations can be used to either discard specific snippets or modify them arbitrarily.

--- a/lua/snippet_converter/config.lua
+++ b/lua/snippet_converter/config.lua
@@ -13,6 +13,10 @@ M.DEFAULT_CONFIG = {
   },
 }
 
+local DEFAULT_FORMAT_OPTS = {
+  generate_package_json = true,
+}
+
 local validate_table = function(name, tbl, is_optional)
   vim.validate {
     [name] = { tbl, "table", is_optional },
@@ -72,6 +76,13 @@ local validate_template = function(template)
   }
   validate_paths("template.sources", template.sources, "source.format", "source.path")
   validate_paths("template.output", template.output, "output.format", "output.path")
+  for output_format, output in pairs(template.output) do
+    validate_table(("template.output.%s.opts"):format(output_format), output.opts, true)
+    if output.opts then
+      output.opts = vim.tbl_deep_extend("force", DEFAULT_FORMAT_OPTS, output.opts)
+    end
+  end
+
   vim.validate {
     ["template.sort_snippets"] = { template.sort_snippets, "function", true },
   }

--- a/lua/snippet_converter/core/vscode/converter.lua
+++ b/lua/snippet_converter/core/vscode/converter.lua
@@ -164,13 +164,17 @@ M.export = function(converted_snippets, filetype, output_dir, _)
 end
 
 -- @param context []? @A table of additional snippet contexts optionally provided the source parser (e.g. extends directives from UltiSnips)
-M.post_export = function(template, filetypes, output_path, context)
+M.post_export = function(template_name, filetypes, output_path, context, template_opts)
+  if template_opts and not template_opts.generate_package_json then
+    return
+  end
+
   filetypes = vim.tbl_filter(function(ft)
     return ft ~= "package"
   end, filetypes)
 
   local json_string =
-    get_package_json_string(template.name, tbl.concat_arrays(filetypes, context.include_filetypes or {}))
+    get_package_json_string(template_name, tbl.concat_arrays(filetypes, context.include_filetypes or {}))
   local lines = export_utils.snippet_strings_to_lines { json_string }
   io.write_file(lines, io.get_containing_folder(output_path) .. "/package.json")
 end

--- a/lua/snippet_converter/init.lua
+++ b/lua/snippet_converter/init.lua
@@ -259,7 +259,13 @@ local convert_snippets = function(model, snippets, context, template)
     end
     if converter.post_export then
       for _, output_path in ipairs(output_dirs) do
-        converter.post_export(template, filetypes, output_path, context)
+        converter.post_export(
+          template.name,
+          filetypes,
+          output_path,
+          context,
+          template.output[target_format].opts
+        )
       end
     end
   end

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -1,3 +1,0 @@
-describe("Config should", function()
-  it("disallow file name for VSCode output path", function() end)
-end)

--- a/tests/init/init_spec.lua
+++ b/tests/init/init_spec.lua
@@ -345,7 +345,7 @@ describe("Snippet converter", function()
     )
   end)
 
-  it("#xxx should skip package.json input file when using vscode format", function()
+  it("should skip package.json input file when using vscode format", function()
     local package_snippet = create_test_snippet("B", "", {})
     package_snippet.path = "some/path/package.json"
 


### PR DESCRIPTION
@doubleChu I have implemented your feature request in this PR. Please test it and let me know what you think about the API and if everything works as expected for you. Doc updates are still missing.

You can now do the following on a per output format basis:
```lua
output = {
  vscode_luasnip = {
    "output_path",
    opts = {
      generate_package_json = false,  
    },
  }
}
```
Closes #7.