### PR TITLE
fix(vsnip): escape $ in text nodes during conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Parse, transform and convert snippets. Supports a variety of formats and snippet engines.
 
-Current version: `1.4.0`
+Current version: `1.4.1`
 
 [![Neovim](https://img.shields.io/badge/Neovim%200.7+-green.svg?style=for-the-badge&logo=neovim)](https://neovim.io)
 [![Lua](https://img.shields.io/badge/Lua-blue.svg?style=for-the-badge&logo=lua)](http://www.lua.org)

--- a/lua/snippet_converter/core/vscode/vsnip/converter.lua
+++ b/lua/snippet_converter/core/vscode/vsnip/converter.lua
@@ -1,4 +1,3 @@
-local base_converter = require("snippet_converter.core.converter")
 local vscode_converter = require("snippet_converter.core.vscode.converter")
 local NodeType = require("snippet_converter.core.node_type")
 
@@ -15,12 +14,8 @@ local node_visitor = setmetatable({
   end,
 }, { __index = vscode_converter.node_visitor })
 
-M.visit_node = setmetatable(node_visitor, {
-  __index = base_converter.visit_node(node_visitor),
-})
-
 M.convert = function(snippet)
-  return vscode_converter.convert(snippet, M.visit_node)
+  return vscode_converter.convert(snippet, node_visitor)
 end
 
 return M

--- a/lua/snippet_converter/init.lua
+++ b/lua/snippet_converter/init.lua
@@ -306,7 +306,11 @@ M.convert_snippets = function(args)
   return model
 end
 
--- ## 1.4.0 (TODO)
+-- ## 1.4.1 (January 8, 2023)
+-- Bug fixes:
+-- - vsnip converter: escape $ in text nodes
+--
+-- ## 1.4.0 (November 9, 2022)
 -- New features:
 -- - added support for YASnippet (an Emacs snippet engine)
 --
@@ -345,6 +349,6 @@ end
 -- ## 1.0.0 (May 2022)
 -- Initial release of SnippetConverter! Currently supports UltiSnips, LuaSnip, SnipMate,
 -- VSCode and vsnip snippets.
-M.version = "1.4.0"
+M.version = "1.4.1"
 
 return M

--- a/tests/core/vscode/vsnip/converter_spec.lua
+++ b/tests/core/vscode/vsnip/converter_spec.lua
@@ -1,8 +1,8 @@
 local NodeType = require("snippet_converter.core.node_type")
 local converter = require("snippet_converter.core.vscode.vsnip.converter")
 
-describe("vsnip converter", function()
-  it("should convert Vimscript code", function()
+describe("vsnip converter should", function()
+  it("convert Vimscript code", function()
     local snippet = {
       name = "user",
       trigger = "username",
@@ -16,6 +16,22 @@ describe("vsnip converter", function()
       trigger = "username",
       body = "${VIM:\\$USER}",
     }
+    assert.are_same(expected, actual)
+  end)
+
+  it("escape $ in text node #16", function()
+    local snippet = {
+      trigger = "fn",
+      body = {
+        { type = NodeType.TEXT, text = "$option" },
+      },
+    }
+    local expected = {
+      trigger = "fn",
+      body = "\\$option",
+    }
+
+    local actual = converter.convert(snippet)
     assert.are_same(expected, actual)
   end)
 end)


### PR DESCRIPTION
Closes #16.