### PR TITLE
feat: add optional json5 support for parsing JSONC snippet files

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ Is there any other snippet engine or custom format that you think should be supp
 
 ## Requirements
 - Neovim ≥ 0.7
+- (Optional) [lua-json5](https://github.com/Joakker/lua-json5) — required for parsing VSCode snippet files that contain comments (JSONC). Install it alongside snippet-converter:
+  ```lua
+  -- lazy.nvim
+  { "Joakker/lua-json5", build = "./install.sh" }
+  -- packer.nvim
+  use { "Joakker/lua-json5", run = "./install.sh" }
+  ```
 
 ## Getting started
 

--- a/lua/snippet_converter/utils/io.lua
+++ b/lua/snippet_converter/utils/io.lua
@@ -91,8 +91,13 @@ M.write_file = function(object, path)
   vim.fn.writefile(object, path)
 end
 
+local has_json5, json5 = pcall(require, "json5")
+
 M.read_json = function(path)
   local lines = table.concat(M.read_file(path), "\n")
+  if has_json5 then
+    return json5.parse(lines)
+  end
   return vim.json.decode(lines)
 end
 

--- a/tests/utils/io_spec.lua
+++ b/tests/utils/io_spec.lua
@@ -1,0 +1,82 @@
+local io_utils = require("snippet_converter.utils.io")
+
+describe("IO utils - read_json", function()
+  local write_temp_json = function(content)
+    local path = vim.fn.tempname()
+    vim.fn.writefile(vim.split(content, "\n"), path)
+    return path
+  end
+
+  describe("standard JSON", function()
+    it("parses valid JSON", function()
+      local path = write_temp_json([[
+{
+  "key": "value",
+  "num": 42
+}]])
+      local result = io_utils.read_json(path)
+      assert.are_same({ key = "value", num = 42 }, result)
+    end)
+
+    it("parses empty JSON object", function()
+      local path = write_temp_json("{}")
+      local result = io_utils.read_json(path)
+      assert.are_same({}, result)
+    end)
+
+    it("parses nested objects and arrays", function()
+      local path = write_temp_json([[
+{
+  "list": [1, 2, 3],
+  "obj": { "inner": true }
+}]])
+      local result = io_utils.read_json(path)
+      assert.are_same({ list = { 1, 2, 3 }, obj = { inner = true } }, result)
+    end)
+  end)
+
+  describe("JSONC (requires json5)", function()
+    it("strips // line comments before parsing", function()
+      local path = write_temp_json([[
+// Place your global snippets here.
+{
+  "key": "value"
+}]])
+      local result = io_utils.read_json(path)
+      assert.are_same({ key = "value" }, result)
+    end)
+
+    it("strips inline // comments", function()
+      local path = write_temp_json([[
+{
+  "key": "value", // inline comment
+  "num": 42 // another
+}]])
+      local result = io_utils.read_json(path)
+      assert.are_same({ key = "value", num = 42 }, result)
+    end)
+
+    it("strips /* */ block comments", function()
+      local path = write_temp_json([[
+{
+  /* block comment */
+  "key": "value"
+}]])
+      local result = io_utils.read_json(path)
+      assert.are_same({ key = "value" }, result)
+    end)
+
+    it("preserves // inside string values", function()
+      local path = write_temp_json([[
+{
+  "url": "https://example.com/path",
+  "comment": "// not a comment"
+}]])
+      local result = io_utils.read_json(path)
+      assert.are_same({
+        url = "https://example.com/path",
+        comment = "// not a comment",
+      }, result)
+    end)
+  end)
+end)


### PR DESCRIPTION
VSCode/VSCodium uses JSONC (JSON with Comments) for .code-snippets files. When lua-json5 is available, read_json uses json5.parse which natively supports comments, trailing commas, and other JSON5 features. Falls back to vim.json.decode when json5 is not installed.

The lua-json5 library is optional — install it alongside snippet-converter for full VSCode snippet compatibility.