### PR TITLE
feat: generate correct filetypes in package.json from snippet scopes

### DIFF
--- a/lua/snippet_converter/core/vscode/converter.lua
+++ b/lua/snippet_converter/core/vscode/converter.lua
@@ -95,11 +95,11 @@ M.visit_node = setmetatable(M.node_visitor, {
 ---@filetypes array an array of filetypes that determine the language and path attribute
 ---@langs_per_filetype table<string, table<string>> maps a filetype to a list of language that this filetype should be active for
 ---@return string the generated string to be written
-local get_package_json_string = function(name, filetypes, langs_per_filetype)
+local get_package_json_string = function(name, filetypes, langs_per_filetype, snippet_scopes)
   local snippets = {}
   for i, ft in ipairs(filetypes) do
     snippets[i] = {
-      language = langs_per_filetype[ft] or { ft },
+      language = (snippet_scopes and snippet_scopes[ft]) or langs_per_filetype[ft] or { ft },
       path = ("./%s.json"):format(ft),
     }
   end
@@ -185,7 +185,7 @@ M.post_export = function(template_name, filetypes, output_path, context, templat
     return ft ~= "package"
   end, filetypes)
 
-  local json_string = get_package_json_string(template_name, filetypes, context.langs_per_filetype or {})
+  local json_string = get_package_json_string(template_name, filetypes, context.langs_per_filetype or {}, context.collected_scopes)
   local lines = export_utils.snippet_strings_to_lines { json_string }
   io.write_file(lines, io.get_containing_folder(output_path) .. "/package.json")
 end

--- a/lua/snippet_converter/init.lua
+++ b/lua/snippet_converter/init.lua
@@ -254,6 +254,24 @@ local convert_snippets = function(model, snippets, context, template)
           end
           -- Store filetype in case they are needed (e.g. for creating a package.json file)
           filetypes[#filetypes + 1] = filetype
+
+          -- Collect distinct scopes from parsed snippets for package.json language field
+          if not context.collected_scopes then
+            context.collected_scopes = {}
+          end
+          local scope_set = {}
+          for _, snippet in ipairs(_snippets) do
+            if snippet.scope then
+              for _, lang in ipairs(snippet.scope) do
+                scope_set[lang] = true
+              end
+            end
+          end
+          if next(scope_set) then
+            local scope_list = vim.tbl_keys(scope_set)
+            table.sort(scope_list)
+            context.collected_scopes[filetype] = scope_list
+          end
         end
         model:complete_task(template, source_format, target_format, output_dirs, converter_errors)
       end

--- a/lua/snippet_converter/init.lua
+++ b/lua/snippet_converter/init.lua
@@ -230,6 +230,25 @@ local convert_snippets = function(model, snippets, context, template)
 
           sort_snippets(source_format, template, _snippets)
 
+          -- Collect distinct scopes from parsed snippets for package.json language field
+          -- (must be done before convert, which mutates scope to a string)
+          if not context.collected_scopes then
+            context.collected_scopes = {}
+          end
+          local scope_set = {}
+          for _, snippet in ipairs(_snippets) do
+            if snippet.scope then
+              for _, lang in ipairs(snippet.scope) do
+                scope_set[lang] = true
+              end
+            end
+          end
+          if next(scope_set) then
+            local scope_list = vim.tbl_keys(scope_set)
+            table.sort(scope_list)
+            context.collected_scopes[filetype] = scope_list
+          end
+
           for _, snippet in ipairs(_snippets) do
             if not skip_snippet[snippet] then
               local ok, converted_snippet = pcall(converter.convert, snippet, nil, opts)
@@ -254,24 +273,6 @@ local convert_snippets = function(model, snippets, context, template)
           end
           -- Store filetype in case they are needed (e.g. for creating a package.json file)
           filetypes[#filetypes + 1] = filetype
-
-          -- Collect distinct scopes from parsed snippets for package.json language field
-          if not context.collected_scopes then
-            context.collected_scopes = {}
-          end
-          local scope_set = {}
-          for _, snippet in ipairs(_snippets) do
-            if snippet.scope then
-              for _, lang in ipairs(snippet.scope) do
-                scope_set[lang] = true
-              end
-            end
-          end
-          if next(scope_set) then
-            local scope_list = vim.tbl_keys(scope_set)
-            table.sort(scope_list)
-            context.collected_scopes[filetype] = scope_list
-          end
         end
         model:complete_task(template, source_format, target_format, output_dirs, converter_errors)
       end

--- a/tests/core/vscode/converter_spec.lua
+++ b/tests/core/vscode/converter_spec.lua
@@ -327,3 +327,46 @@ describe("VSCode converter (luasnip flavor) should", function()
     }, actual)
   end)
 end)
+
+describe("get_package_json_string", function()
+  it("uses filename-derived filetype when no scopes available", function()
+    local result = converter._get_package_json_string("t1", { "media" }, {})
+    assert.is_true(result:find([["media"]]), "should include filetype")
+    assert.is_true(result:find([["./media.json"]]), "should include path")
+    assert.is_false(result:find([["php"]]), "should not include scope filetypes")
+  end)
+
+  it("uses collected snippet scopes for language when available", function()
+    local scopes = { media = { "css", "html", "php" } }
+    local result = converter._get_package_json_string("t1", { "media" }, {}, scopes)
+    assert.is_true(result:find([["css"]]), "should include css")
+    assert.is_true(result:find([["html"]]), "should include html")
+    assert.is_true(result:find([["php"]]), "should include php")
+    assert.is_false(result:find([["media"]]), "should not use filename filetype")
+  end)
+
+  it("falls back to langs_per_filetype when no scopes and no filetype match", function()
+    local langs = { media = { "vim", "neovim" } }
+    local result = converter._get_package_json_string("t1", { "media" }, langs)
+    assert.is_true(result:find([["vim"]]), "should include vim")
+    assert.is_true(result:find([["neovim"]]), "should include neovim")
+  end)
+
+  it("snippet scopes take priority over langs_per_filetype", function()
+    local scopes = { media = { "css", "php" } }
+    local langs = { media = { "vim" } }
+    local result = converter._get_package_json_string("t1", { "media" }, langs, scopes)
+    assert.is_true(result:find([["css"]]), "should include css from scopes")
+    assert.is_true(result:find([["php"]]), "should include php from scopes")
+    assert.is_false(result:find([["vim"]]), "should not include vim from langs")
+  end)
+
+  it("handles multiple filetypes with mixed scopes", function()
+    local scopes = { all = { "php", "html" } }
+    -- "css" not in scopes, falls back to filename
+    local result = converter._get_package_json_string("t1", { "all", "css" }, {}, scopes)
+    assert.is_true(result:find([["php"]]), "should include php for all")
+    assert.is_true(result:find([["html"]]), "should include html for all")
+    assert.is_true(result:find([["css"]]), "should include css filetype fallback")
+  end)
+end)


### PR DESCRIPTION
When converting VSCode snippets, the package.json language field was derived from the source filename (e.g. 'media' from media.code-snippets), ignoring individual snippet scope fields. LuaSnip's package.json-based loader ignores per-snippet scope, so all snippets were registered only for the filename-derived filetype.

This change collects the unique scopes from all parsed snippets and uses them as the language array in the generated package.json, falling back to the filename-derived filetype when no scopes are present.